### PR TITLE
Implement a ffprobe based media file metadata extraction

### DIFF
--- a/hask-gallery.cabal
+++ b/hask-gallery.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2b495392a6314d897b3a2f8099ba567d47d010fb1b50033abc63825891bbc48b
+-- hash: 0389de5afb2c0d0c7d2eb9ef32784022245941552ac2f5918e667ac7a9d1bb38
 
 name:           hask-gallery
 version:        0.1.0.0
@@ -32,6 +32,7 @@ library
       Models.Base
       Models.Settings
       Models.Video
+      Probe.FFProbe
       Utils
   other-modules:
       Paths_hask_gallery
@@ -47,9 +48,11 @@ library
     , executable-path >=0.0.3.1 && <0.0.4
     , filepath >=1.4.2.1 && <1.5
     , parseargs >=0.2.0.9 && <0.3
-    , regex >=1.1.0.0 && <1.2
+    , process >=1.6.8.0 && <1.6.9
+    , regex-tdfa >=1.3.0 && <1.4
     , servant >=0.16.2 && <0.17.0
     , servant-server >=0.16.2 && <0.18
+    , split >=0.2.3.4 && <0.2.4
     , text >=1.2.4.0 && <1.3
     , utf8-string >=1.0.1.1 && <2.0
     , wai >=3.2.2.1 && <3.3
@@ -74,9 +77,11 @@ executable hask-gallery-exe
     , filepath >=1.4.2.1 && <1.5
     , hask-gallery
     , parseargs >=0.2.0.9 && <0.3
-    , regex >=1.1.0.0 && <1.2
+    , process >=1.6.8.0 && <1.6.9
+    , regex-tdfa >=1.3.0 && <1.4
     , servant >=0.16.2 && <0.17.0
     , servant-server >=0.16.2 && <0.18
+    , split >=0.2.3.4 && <0.2.4
     , text >=1.2.4.0 && <1.3
     , utf8-string >=1.0.1.1 && <2.0
     , wai >=3.2.2.1 && <3.3
@@ -102,9 +107,11 @@ test-suite hask-gallery-test
     , filepath >=1.4.2.1 && <1.5
     , hask-gallery
     , parseargs >=0.2.0.9 && <0.3
-    , regex >=1.1.0.0 && <1.2
+    , process >=1.6.8.0 && <1.6.9
+    , regex-tdfa >=1.3.0 && <1.4
     , servant >=0.16.2 && <0.17.0
     , servant-server >=0.16.2 && <0.18
+    , split >=0.2.3.4 && <0.2.4
     , tasty >=1.2.3 && <1.3.0
     , tasty-hunit >=0.10.0.0 && <0.11
     , tasty-quickcheck >=0.10.0.0 && <0.11

--- a/package.yaml
+++ b/package.yaml
@@ -34,9 +34,10 @@ dependencies:
 - filepath >= 1.4.2.1 && < 1.5
 - bytestring >= 0.10.10.0 && < 1.0
 - utf8-string >= 1.0.1.1 && < 2.0
-- directory >= 1.3.6.0 && < 1.4
 - executable-path >= 0.0.3.1 && < 0.0.4
-- regex >= 1.1.0.0 && < 1.2
+- regex-tdfa >= 1.3.0 && < 1.4
+- process >= 1.6.8.0 && < 1.6.9
+- split >= 0.2.3.4 && < 0.2.4
 library:
   source-dirs: src
 

--- a/src/Management/Command.hs
+++ b/src/Management/Command.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Management.Command (
         exec
     ) where

--- a/src/Probe/FFProbe.hs
+++ b/src/Probe/FFProbe.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Probe.FFProbe (
+         probeInstalled
+        ,probeFile
+        --,getDimensions
+        --,getDuration
+        --,getMediaType
+        --,getModifiedAt
+        --,getCreatedAt
+        ,Mediatype(..)
+    ) where
+
+import Data.Eq (Eq)
+import Data.List.NonEmpty (NonEmpty)
+import Data.List (foldl)
+import Data.List.Split (endBy)
+import Data.Int (Int)
+import Data.Maybe
+import Data.String (String)
+import Data.Bool (Bool)
+import System.Directory ( getHomeDirectory )
+import System.Exit ( ExitCode(..) )
+import System.FilePath (FilePath)
+import System.IO (IO, putStrLn)
+import System.Process ( readProcessWithExitCode )
+import Prelude (otherwise, return, (==), (||), ($), (/=))
+
+--------------------------------------------------------------------------------------------------
+ffprobe :: String
+ffprobe = "ffprobe"
+
+--------------------------------------------------------------------------------------------------
+data Mediatype = MediaAudio|MediaVideo|MediaUnknow deriving Eq
+
+data MediaInfo = MediaInfo {
+         mediaType ::Mediatype
+        ,duration ::Int
+        ,modifiedAt ::Int
+        ,createdAt ::Int
+        ,dimensions :: (Int,Int)
+    }
+
+--------------------------------------------------------------------------------------------------
+ffprobeExec :: String -> IO (Maybe String)
+ffprobeExec filepath = do
+    (exitCode, stdOut, stdErr) <- readProcessWithExitCode (ffprobe) ["-i", filepath] ""
+    if exitCode /= ExitSuccess
+        then return Nothing
+        else return $ Just stdOut
+
+--------------------------------------------------------------------------------------------------
+dimensionsRegex :: String
+dimensionsRegex = "([0-9]{3,5}x[0-9]{3,5})"
+
+--------------------------------------------------------------------------------------------------
+durationRegex :: String
+durationRegex = "Duration:[ ]+([0-9]{2}:[0-9]{2}:[0-9]{2})"
+
+--------------------------------------------------------------------------------------------------
+parseDuration :: String -> Int
+parseDuration text = 0
+
+--------------------------------------------------------------------------------------------------
+parseDimensions :: Int -> Int -> String -> (Int, Int)
+parseDimensions width height text = (0, 0)
+
+--------------------------------------------------------------------------------------------------
+parseMediaType :: String -> Mediatype
+parseMediaType text = MediaUnknow
+
+--------------------------------------------------------------------------------------------------
+type ParseData = (Mediatype, Int, (Int, Int))
+emptyParseData :: ParseData
+emptyParseData = (MediaUnknow, 0, (0, 0))
+
+--------------------------------------------------------------------------------------------------
+parseNext :: ParseData  -> String -> ParseData
+parseNext (mType, duration, (width, height)) text = (
+         if mType == MediaUnknow
+            then parseMediaType text
+            else mType
+        ,if duration == 0
+            then parseDuration text
+            else duration
+        ,if (width == 0) || (height == 0)
+            then parseDimensions width height text
+            else (width, height)
+    )
+
+--------------------------------------------------------------------------------------------------
+parseAll :: [String] -> (Mediatype, Int, (Int, Int))
+parseAll contents = foldl (\last line -> parseNext last line) emptyParseData $ contents
+
+--------------------------------------------------------------------------------------------------
+parseInfo :: Int -> Int -> [String] -> MediaInfo
+parseInfo mCreatedAt mModifiedAt contents = MediaInfo {
+         mediaType=mType
+        ,duration=mDuration
+        ,modifiedAt=mModifiedAt
+        ,createdAt=mCreatedAt
+        ,dimensions=mDimensions
+    } where
+        (mType, mDuration, mDimensions) = parseAll contents
+
+--------------------------------------------------------------------------------------------------
+probeInstalled :: IO Bool
+probeInstalled = do
+    (exitCode, stdOut, stdErr) <- readProcessWithExitCode (ffprobe) ["--version"] ""
+    return $ exitCode == ExitSuccess
+
+--------------------------------------------------------------------------------------------------
+getModificationTime :: FilePath -> IO Int
+getModificationTime filepath = do
+    return 0
+
+--------------------------------------------------------------------------------------------------
+getCreationTime :: FilePath -> IO Int
+getCreationTime filepath = do
+    return 0
+
+--------------------------------------------------------------------------------------------------
+probeFile :: FilePath -> IO (Maybe MediaInfo)
+probeFile filepath = do
+    probedData <- ffprobeExec filepath
+    mCreatedAt <- getCreationTime filepath
+    mModifiedAt <- getModificationTime filepath
+    case probedData of
+        Just info -> return $ Just $ parseInfo mCreatedAt mModifiedAt $ endBy "\n" info
+        Nothing -> return Nothing

--- a/src/Probe/FFProbe.hs
+++ b/src/Probe/FFProbe.hs
@@ -5,11 +5,9 @@
 module Probe.FFProbe (
          probeInstalled
         ,probeFile
-        --,getDimensions
-        --,getDuration
-        --,getMediaType
-        --,getModifiedAt
-        --,getCreatedAt
+        ,getDimensions
+        ,getDuration
+        ,getMediaType
         ,Mediatype(..)
     ) where
 
@@ -45,6 +43,18 @@ data MediaInfo = MediaInfo {
         ,duration ::String
         ,dimensions :: (Int,Int)
     } deriving (Show, Eq)
+
+--------------------------------------------------------------------------------------------------
+getDimensions :: MediaInfo -> (Int, Int)
+getDimensions (MediaInfo _  _ dim) = dim
+
+--------------------------------------------------------------------------------------------------
+getDuration :: MediaInfo -> String
+getDuration (MediaInfo _  dur _) = dur
+
+--------------------------------------------------------------------------------------------------
+getMediaType :: MediaInfo -> Mediatype
+getMediaType (MediaInfo mtype  _ _) = mtype
 
 --------------------------------------------------------------------------------------------------
 ffprobeExec :: String -> IO (Maybe String)


### PR DESCRIPTION
ffprobe is a tool provide by https://ffmpeg.org/ffprobe.html.

This implemented module use ffprobe to discovery some information about the media file.
It calls ffprobe and scan it's stdout output to get informations such duration and dimensions.