### PR TITLE
Add support to HTTP_RANGE headers

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,1 +1,2 @@
 [x] Separate util functions like getBaseDirectory in other modules
+[ ] Do not allow to run the server without defining a gallery path and scanning the files

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -21,13 +21,14 @@ import Data.String (String)
 import Prelude (($), return)
 import Servant (ServerT(..), Proxy(..), JSON)
 import Servant.API  (Capture(..), CaptureAll(..), Get(..), (:<|>)(..), (:>)(..))
+import qualified Servant.API.Header as RQ
 
 --------------------------------------------------------------------------------------------------
 type GalleryApi =
     "health-check" :> "liveness" :> HC.HealthCheck
     :<|> "health-check" :> "readiness" :> HC.HealthCheckReadiness
     :<|> "videos" :> Capture "seed" Int :> Capture "page" Word32 :> VG.GetVideoList
-    :<|> "files" :> Capture "gallery" String :>  CaptureAll "path" String :> VF.GetFile
+    :<|> RQ.Header "Range" String :> "files" :> Capture "gallery" String :>  CaptureAll "path" String :> VF.GetFile
     :<|> CaptureAll "path" String :> VS.GetAsset
 
 --------------------------------------------------------------------------------------------------

--- a/src/Stream/File.hs
+++ b/src/Stream/File.hs
@@ -4,9 +4,18 @@ module Stream.File (
 
 import qualified Data.ByteString.Lazy as L
 import Data.Int (Int)
-import Data.ByteString.Builder
 import System.FilePath (FilePath)
+import System.IO (IO, withBinaryFile, hFileSize, hSeek, IOMode(ReadMode), SeekMode(AbsoluteSeek))
+import Prelude (fromInteger, toInteger, (<), (>=), (<=), (&&), (-), ($))
 
 --------------------------------------------------------------------------------------------------
-streamFile :: FilePath -> Int -> IO L.ByteString
-streamFile filePath seekPosition = L.readFile filePath
+streamFile :: FilePath -> Int -> Int -> IO L.ByteString
+streamFile filePath seekPosition bytes2Read =
+    withBinaryFile  filePath ReadMode $ \h -> do
+        fileSizeI <- hFileSize h
+        let fileSize = (fromInteger fileSizeI) ::Int
+        let seekPos = (if seekPosition <= fileSize then seekPosition else fileSize)
+        hSeek h AbsoluteSeek $ toInteger seekPos
+        let filesz = (fileSize - seekPos)
+        let limit = (if ((bytes2Read >= 0) && (bytes2Read <= filesz)) then bytes2Read else filesz)
+        L.hGet h limit

--- a/src/Stream/File.hs
+++ b/src/Stream/File.hs
@@ -1,21 +1,47 @@
 module Stream.File (
-        streamFile
+         getSeekRange
+        ,getFileSize
+        ,streamFile
+        ,RangeInfo
     ) where
 
 import qualified Data.ByteString.Lazy as L
 import Data.Int (Int)
 import System.FilePath (FilePath)
-import System.IO (IO, withBinaryFile, hFileSize, hSeek, IOMode(ReadMode), SeekMode(AbsoluteSeek))
-import Prelude (fromInteger, toInteger, (<), (>=), (<=), (&&), (-), ($))
+import System.IO (withBinaryFile, hFileSize, hSeek, IO, Handle, IOMode(ReadMode), SeekMode(AbsoluteSeek))
+import Prelude (return, fromInteger, toInteger, (<), (>=), (<=), (&&), (-), ($))
+
+--------------------------------------------------------------------------------------------------
+type RangeInfo =  (Int, Int, Int)
+
+--------------------------------------------------------------------------------------------------
+getSeekRangeH :: Handle -> Int -> Int -> IO RangeInfo
+getSeekRangeH h seekPosition bytes2Read = do
+        fileSizeI <- hFileSize h
+        let fileSize = (fromInteger fileSizeI) ::Int
+        let seekPos = (if seekPosition < fileSize then seekPosition else fileSize - 1)
+        let filesz = (fileSize - seekPos)
+        let limit = (if ((bytes2Read >= 0) && (bytes2Read < filesz)) then bytes2Read else filesz)
+        return (seekPos, limit, fileSize)
+
+--------------------------------------------------------------------------------------------------
+getSeekRange :: FilePath -> Int -> Int -> IO RangeInfo
+getSeekRange filePath seekPosition bytes2Read =
+    withBinaryFile filePath ReadMode $ \h -> do
+        rangeInfo <- getSeekRangeH h seekPosition bytes2Read
+        return rangeInfo
+
+--------------------------------------------------------------------------------------------------
+getFileSize :: FilePath -> IO Int
+getFileSize filePath =
+    withBinaryFile filePath ReadMode $ \h -> do
+        fileSizeI <- hFileSize h
+        return $ fromInteger fileSizeI
 
 --------------------------------------------------------------------------------------------------
 streamFile :: FilePath -> Int -> Int -> IO L.ByteString
 streamFile filePath seekPosition bytes2Read =
-    withBinaryFile  filePath ReadMode $ \h -> do
-        fileSizeI <- hFileSize h
-        let fileSize = (fromInteger fileSizeI) ::Int
-        let seekPos = (if seekPosition <= fileSize then seekPosition else fileSize)
+    withBinaryFile filePath ReadMode $ \h -> do
+        (seekPos, limit, fileSize) <- getSeekRangeH h seekPosition bytes2Read
         hSeek h AbsoluteSeek $ toInteger seekPos
-        let filesz = (fileSize - seekPos)
-        let limit = (if ((bytes2Read >= 0) && (bytes2Read <= filesz)) then bytes2Read else filesz)
         L.hGet h limit

--- a/src/Views/Base.hs
+++ b/src/Views/Base.hs
@@ -58,17 +58,16 @@ takeExtensionInLower :: FilePath -> T.Text
 takeExtensionInLower filePath =
     T.pack $ UT.lowerPath $ takeExtension filePath
 
-
 --------------------------------------------------------------------------------------------------
-getHeaderMime :: FilePath -> LBS.ByteString
-getHeaderMime filePath = LBS.fromChunks [(defaultMimeLookup (takeExtensionInLower filePath))]
+mimeFromPath :: FilePath -> LBS.ByteString
+mimeFromPath filePath = LBS.fromChunks [(defaultMimeLookup (takeExtensionInLower filePath))]
 
 --------------------------------------------------------------------------------------------------
 responseWithMime :: FilePath -> B.ByteString -> WithCT
 responseWithMime filePath rawData =
-    WithCT { header=getHeaderMime filePath , content=LBS.fromChunks [rawData] }
+    WithCT { header=mimeFromPath filePath , content=LBS.fromChunks [rawData] }
 
 --------------------------------------------------------------------------------------------------
 lazyResponseWithMime :: FilePath -> LBS.ByteString -> WithCT
 lazyResponseWithMime filePath rawData =
-    WithCT { header=getHeaderMime filePath, content=rawData }
+    WithCT { header=mimeFromPath filePath, content=rawData }

--- a/src/Views/File.hs
+++ b/src/Views/File.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators     #-}
 
 module Views.File (
          getFile
@@ -19,25 +21,91 @@ import Control.Monad.STM (atomically)
 import Control.Monad.Trans.Reader (ask)
 import qualified Data.ByteString.Lazy as LBS
 import Data.String (String)
-import Servant.API (Get, GetPartialContent)
-import Prelude (return, ($))
+import Data.List (elem, (++))
+import Data.Int (Int)
+import Data.Maybe
+import Servant.API (Get, GetPartialContent, (:>))
+import qualified Servant.API.ResponseHeaders as RH
+import qualified Servant.API.Header as RQ
+import Prelude (return, read, ($), (<$>), (==), (/=), (>=), (<), (+), (-))
 import System.IO (IO)
 import Servant (OctetStream)
 import Servant (serveDirectory)
 import Servant.Server.Internal.Handler (Handler(..))
 import System.FilePath.Posix ((</>))
+import System.FilePath (FilePath)
+import Text.Show (show)
 
 ---------------------------------------------------------------------------------------------------
-type  GetFile = Get '[OctetStream] VB.WithCT
+type  FileRangeResponse = (RH.Headers ContentHeaders VB.WithCT)
+type  GetFile = GetPartialContent '[OctetStream] FileRangeResponse
 
-getFile :: String -> [String] -> VB.GalleryMonad VB.WithCT
-getFile galleryName path = do  -- galleryName wiil be used to switch between video, music and photo galleries
+type ContentHeaders =
+    '[ RQ.Header "Accept-Ranges" String
+     , RQ.Header "Content-Length" String
+     , RQ.Header "Content-Range" String
+     ]
+
+beforeDash :: String -> String
+beforeDash [] = []
+beforeDash (s:m:xs) = [s] ++ if m == '-' then [] else beforeDash (m:xs)
+beforeDash _ = []
+
+afterDash :: String -> String
+afterDash [] = []
+afterDash (s:xs) = if '-' `elem` xs then afterDash xs else xs
+
+
+parseRange :: String -> (Int, Int)
+parseRange ('-':xs) = ((read (['-'] ++ xs) ::Int), 0)
+parseRange mrange =
+    if '-' `elem` mrange
+        then
+            ((read $ beforeDash mrange) ::Int, ((read $afterDash mrange) ::Int) + 1)
+        else (0, 0)
+
+adaptRange :: Int -> ( Int, Int ) -> Maybe ( Int, Int )
+adaptRange fileSize (start, stop) =
+    if start < 0
+        then (if (fileSize + start) >= 0 then Just (fileSize + start, fileSize) else Just (0, fileSize))
+        else (if ((start + stop) == 0) then Nothing else Just (start, stop))
+
+seekPosLimitFromRange :: (Int, Int) -> (Int, Int)
+seekPosLimitFromRange (rstart, rstop) = (rstart, rstop - rstart)
+
+serveFileAtRange :: Maybe String -> FilePath -> VB.GalleryMonad FileRangeResponse
+serveFileAtRange requestRange filePath = do
+    fileSize <- liftIO $ SF.getFileSize filePath
+
+    let mRange = (
+            if requestRange /= Nothing
+                then adaptRange fileSize $ parseRange $ fromJust requestRange
+                else Nothing)
+
+    let (seekPos, limit) = (
+            if mRange == Nothing
+                then ( 0, fileSize )
+                else (seekPosLimitFromRange $ fromJust mRange))
+
+    fileContents <- liftIO $ SF.streamFile filePath seekPos limit
+    let rangeHeader = ("bytes " ++ (show seekPos) ++ "-" ++ (show (seekPos + limit - 1)) ++ "-" ++ (show fileSize))
+    return
+        $ RH.addHeader "bytes"
+        $ RH.addHeader (show limit)
+        $ RH.addHeader rangeHeader
+        $ VB.lazyResponseWithMime filePath fileContents
+
+getFile :: Maybe String -> String -> [String] -> VB.GalleryMonad FileRangeResponse
+getFile mrange galleryName path = do  -- galleryName wiil be used to switch between video, music and photo galleries
     VB.State { VB.videos = p } <- ask
     case galleryName of
         ("videos") -> do
             gallery <- liftIO $ atomically $ readTVar p
             let filePath = (MV.getGalleryPath gallery) </> (UT.relativePathFromList path)
-            fileContents <- liftIO $ SF.streamFile filePath 0 (-1) -- TODO: replace ZERO with a range to seek
-            return $ VB.lazyResponseWithMime filePath fileContents
+            serveFileAtRange mrange filePath
         (_) -> do  -- TODO: create other galleries (music and pictures)
-            return $ VB.lazyResponseWithMime ".txt" LBS.empty
+            return
+                $ RH.addHeader "bytes"
+                $ RH.addHeader "0"
+                $ RH.addHeader "0-0-0"
+                $ VB.lazyResponseWithMime ".txt" LBS.empty

--- a/src/Views/File.hs
+++ b/src/Views/File.hs
@@ -37,7 +37,7 @@ getFile galleryName path = do  -- galleryName wiil be used to switch between vid
         ("videos") -> do
             gallery <- liftIO $ atomically $ readTVar p
             let filePath = (MV.getGalleryPath gallery) </> (UT.relativePathFromList path)
-            fileContents <- liftIO $ SF.streamFile filePath 0 -- TODO: replace ZERO with a range to seek
+            fileContents <- liftIO $ SF.streamFile filePath 0 (-1) -- TODO: replace ZERO with a range to seek
             return $ VB.lazyResponseWithMime filePath fileContents
         (_) -> do  -- TODO: create other galleries (music and pictures)
             return $ VB.lazyResponseWithMime ".txt" LBS.empty


### PR DESCRIPTION
## What
Add support to HTTP_RANGE headers

## Why
It is necessary to the browser start playing the video without have to download the entire file.
It also allow to seek at some time of the video or music being played
